### PR TITLE
Refactor main logic into Game class to fix bug in parsing moves

### DIFF
--- a/python/main.py
+++ b/python/main.py
@@ -4,89 +4,104 @@ from typing import Tuple, Union
 from . import board
 
 
-def parse_move(user_input: str) -> Union[Tuple[int, int], str, None]:
-    if user_input.upper() == "FORFEIT":
-        return "FORFEIT"
-    # Transform to list of 2 strings which were separated by comma or spaces.
-    user_input = user_input.strip(" ([)]'").replace(",", " ").split(maxsplit=1)
-    try:  # Catch the case input can't be converted to int
-        move = tuple(map(int, user_input))
-    except ValueError:
-        return
-    # Check two numbers were entered (case of more than 2 already caught) and
-    # that they are within the required range.
-    if len(move) == 2 and 0 <= move[0] < size and 0 <= move[1] < size:
-        return move
+class Game:
+    """Class representing a tic-tac-toe game."""
+
+    def __init__(self, size: int, depth: int, players: Tuple[str, ...] = ("X", "O")):
+        self.size = size
+        self.depth = depth
+        self.board = board.create_board(size, depth)
+        self.winner = None
+        self.forfeiter = None
+        self.players = players  # Works for more than 2!
+
+    def start(self):
+        print(
+            self.board,
+            textwrap.dedent(
+                f"""
+                Coordinates start from 0 and go up to size-1, and are expressed by [col], [row]
+                e.g. for the bottom left: 0, {self.size-1}
+                Type FORFEIT to forfeit the match.
+                """
+            ),
+            sep="\n",
+        )
+
+        self._mainloop()
+
+        if self.winner:
+            print("Player {} won the game!".format(self.winner))
+        elif self.forfeiter:
+            print("Player {} forfeited the game.".format(self.forfeiter))
+        else:
+            assert False
+
+    def _mainloop(self):
+        move_coords = []
+        player_index = 0
+        while not self.board.check_winner() and not self.forfeiter:
+            player = self.players[player_index]
+            while len(move_coords) < self.depth - 1:
+                coord = None
+                while type(coord) is not tuple:
+                    coord = self._parse_move(
+                        input(
+                            "Player {}, choose board in layer {} (col, row): ".format(
+                                player, self.depth - len(move_coords)
+                            )
+                        )
+                    )
+                move_coords.append(coord)
+                if not self.board.perform_move(None, move_coords):
+                    move_coords.pop()  # Remove invalid choice of board
+            move = None
+            while move is None:
+                move = self._parse_move(input("Move for player {}: ".format(player)))
+                if move is None:
+                    print(
+                        "A valid move is either a coordinate as so: 'col, row', "
+                        "or 'FORFEIT'"
+                    )
+            if move == "FORFEIT":
+                self.forfeiter = player
+            else:
+                move_coords.append(move)
+                is_valid_move = self.board.perform_move(player, move_coords)
+                if is_valid_move:
+                    print(self.board.draw_board(move_coords[1:]))
+                    move_coords.pop(0)
+                    if self.board.check_winner():
+                        self.winner = self.board.check_winner()
+                        break
+                    while not self.board.check_move(move_coords):
+                        move_coords.pop()
+                    player_index = (player_index + 1) % len(self.players)
+                else:
+                    print("The chosen cell is unavailable.")
+                    move_coords.pop()  # Remove the invalid move
+
+    def _parse_move(self, user_input: str) -> Union[Tuple[int, int], str, None]:
+        if user_input.upper() == "FORFEIT":
+            return "FORFEIT"
+        # Transform to list of 2 strings which were separated by comma or spaces.
+        user_input = user_input.strip(" ([)]'").replace(",", " ").split(maxsplit=1)
+        try:  # Catch the case input can't be converted to int
+            move = tuple(map(int, user_input))
+        except ValueError:
+            return
+        # Check two numbers were entered (case of more than 2 already caught) and
+        # that they are within the required range.
+        if len(move) == 2 and 0 <= move[0] < self.size and 0 <= move[1] < self.size:
+            return move
 
 
 def main():
     size = int(input("Size of board: "))
     depth = int(input("Depth of board: "))
 
-    main_board = board.create_board(size, depth)
-
-    winner = None
-    forfeiter = None
-
-    print(
-        main_board,
-        textwrap.dedent(
-            f"""
-            Coordinates start from 0 and go up to size-1, and are expressed by [col], [row]
-            e.g. for the bottom left: 0, {size-1}
-            Type FORFEIT to forfeit the match.
-            """
-        ),
-        sep="\n",
-    )
-    move_coords = []
-    players = ["X", "O"]  # Works for more than 2!
-    player_index = 0
-    while not main_board.check_winner() and not forfeiter:
-        player = players[player_index]
-        while len(move_coords) < depth - 1:
-            coord = None
-            while type(coord) is not tuple:
-                coord = parse_move(
-                    input(
-                        "Player {}, choose board in layer {} (col, row): ".format(
-                            player, depth - len(move_coords)
-                        )
-                    )
-                )
-            move_coords.append(coord)
-            if not main_board.perform_move(None, move_coords):
-                move_coords.pop()  # Remove invalid choice of board
-        move = None
-        while move is None:
-            move = parse_move(input("Move for player {}: ".format(player)))
-            if move is None:
-                print(
-                    "A valid move is either a coordinate as so: 'col, row', "
-                    "or 'FORFEIT'"
-                )
-        if move == "FORFEIT":
-            forfeiter = player
-        else:
-            move_coords.append(move)
-            is_valid_move = main_board.perform_move(player, move_coords)
-            if is_valid_move:
-                print(main_board.draw_board(move_coords[1:]))
-                move_coords.pop(0)
-                if main_board.check_winner():
-                    winner = main_board.check_winner()
-                    break
-                while not main_board.check_move(move_coords):
-                    move_coords.pop()
-                player_index = (player_index + 1) % len(players)
-            else:
-                print("The chosen cell is unavailable.")
-                move_coords.pop()  # Remove the invalid move
-
-    if winner:
-        print("Player {} won the board, and the game!".format(winner))
-    elif forfeiter:
-        print("Player {} forfeited the game.".format(forfeiter))
+    game = Game(size, depth)
+    game.start()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`parse_move()` depends on the size of the boards - makes sense to factor this logic inside a class.

This previously worked because the code under `if __name__ == "__main__"` was in global scope, accessible from the function - this is one reason it's good practice to minimise what's in global scope (now moved to `main()` function).